### PR TITLE
DAOTHER-7191

### DIFF
--- a/wwpdb/apps/ann_tasks_v2/report/PdbxReportDepictBootstrap.py
+++ b/wwpdb/apps/ann_tasks_v2/report/PdbxReportDepictBootstrap.py
@@ -72,6 +72,8 @@ class PdbxReportDepictBootstrap(PdbxDepictBootstrapBase):
                 ("entity", "Entity description", "row-wise"),
                 ("entity_poly", "Polymers", "row-wise"),
                 ("pdbx_entity_branch_list", "Carbohydrate polymers", "row-wise"),
+                ("pdbx_molecule", "PRD", "row-wise"),
+                ("pdbx_molecule_features", "PRD description", "row-wise"),
                 ("entity_src_gen", "Engineered Source", "row-wise"),
                 ("entity_src_nat", "Natural Source", "row-wise"),
                 ("pdbx_entity_src_syn", "Synthetic Source", "row-wise"),

--- a/wwpdb/apps/ann_tasks_v2/report/styles/ModelReport.py
+++ b/wwpdb/apps/ann_tasks_v2/report/styles/ModelReport.py
@@ -134,6 +134,8 @@ class PdbxReportCategoryStyle(PdbxCategoryStyleBase):
         ("entity_branch_list", "table"),
         ("pdbx_struct_ref_seq_depositor_info", "table"),
         ("pdbx_modification_feature", "table"),
+        ("pdbx_molecule", "table"),
+        ("pdbx_molecule_features", "table"),
     ]
     _cDict = {
         "audit_contact_author": [
@@ -1356,7 +1358,19 @@ class PdbxReportCategoryStyle(PdbxCategoryStyleBase):
             ("_pdbx_modification_feature.ref_comp_id", "%s", "str", ""),
             ("_pdbx_modification_feature.type", "%s", "str", ""),
             ("_pdbx_modification_feature.category", "%s", "str", ""),
-        ]
+        ],
+        "pdbx_molecule": [
+            ("_pdbx_molecule.instance_id", "%s", "str", ""),
+            ("_pdbx_molecule.prd_id", "%s", "str", ""),
+            ("_pdbx_molecule.asym_id", "%s", "str", ""),
+        ],
+        "pdbx_molecule_features": [
+            ("_pdbx_molecule_features.prd_id", "%s", "str", ""),
+            ("_pdbx_molecule_features.name", "%s", "str", ""),
+            ("_pdbx_molecule_features.type", "%s", "str", ""),
+            ("_pdbx_molecule_features.class", "%s", "str", ""),
+            ("_pdbx_molecule_features.details", "%s", "str", ""),
+        ],
     }
 
     _excludeList = []


### PR DESCRIPTION
ModelReport.py — Added PRD categories to the style definitions:
Added pdbx_molecule and pdbx_molecule_features to the _categoryInfo list
Added category definitions to _cDict with field mappings:
pdbx_molecule: instance_id, prd_id, asym_id
pdbx_molecule_features: prd_id, name, type, class, details

PdbxReportDepictBootstrap.py — Added PRD tables to the report categories:
Added "PRD" table (pdbx_molecule) after "Carbohydrate polymers"
Added "PRD description" table (pdbx_molecule_features) after "PRD"
Both formatted as row-wise tables, matching existing table styles